### PR TITLE
got the params updated w/ real vals

### DIFF
--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -14,14 +14,14 @@ param workloadName    = 'sbsub'
 // ── Cross-tenant Service Bus (Tenant B) ──────────────────────────────────────
 // Replace with actual values from your Tenant B environment.
 
-param crossTenantServiceBusNamespace = '<tenant-b-servicebus-namespace>.servicebus.windows.net'
-param crossTenantTopicName           = '<topic-name>'
-param crossTenantSubscriptionName    = '<subscription-name>'
-param crossTenantTenantId            = '<tenant-b-entra-tenant-id>'
-param crossTenantAppClientId         = '<app-registration-client-id-in-tenant-b>'
+param crossTenantServiceBusNamespace = 'sbns-x-tenant-ingest.servicebus.windows.net'
+param crossTenantTopicName           = 'publish'
+param crossTenantSubscriptionName    = 'all-messages'
+param crossTenantTenantId            = '596c1564-6e95-4c35-a80b-2dbe45a162f3'
+param crossTenantAppClientId         = 'c4522b48-1222-4db9-85b6-8252dc9c4825'
 
 // ── Runtime tuning ───────────────────────────────────────────────────────────
 
-param messageContainerName  = 'sb-messages'
+param messageContainerName  = 'sbmessages'
 param timerSchedule         = '0 */1 * * * *'
 param maxMessageBatchSize   = 10


### PR DESCRIPTION
This pull request updates several configuration parameters in the `infra/main.bicepparam` file to use actual values for the cross-tenant Service Bus setup and aligns the `messageContainerName` with naming conventions. These changes make the deployment configuration ready for use in the target environment.

Cross-tenant Service Bus configuration updates:

* Set `crossTenantServiceBusNamespace`, `crossTenantTopicName`, `crossTenantSubscriptionName`, `crossTenantTenantId`, and `crossTenantAppClientId` to actual values for Tenant B, replacing placeholder strings.

Runtime tuning:

* Changed `messageContainerName` from `sb-messages` to `sbmessages` for consistency with naming conventions.## Description

<!-- Explain what this PR does and why.  Link the related issue: "Closes #NNN" -->

Closes #

---

## Type of change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Infrastructure change (Bicep templates)
- [ ] CI/CD change (workflow YAML)
- [ ] Documentation only

---

## Changes made

<!-- Bullet-point summary of what changed and why -->

-
-

---

## Checklist

- [ ] Tests added or updated to cover the change
- [ ] All existing tests pass: `python -m pytest tests/ -v`
- [ ] `README.md` updated if behavior, settings, or deployment steps changed
- [ ] `CHANGELOG.md` `[Unreleased]` section updated
- [ ] No secrets, connection strings, or tenant IDs committed
- [ ] Bicep builds cleanly: `az bicep build --file infra/main.bicep` (if Bicep changed)
- [ ] PR title follows Conventional Commits format: `<type>(<scope>): <summary>`

---

## Testing notes

<!-- Describe how you tested this change.  Include local test steps if relevant. -->

---

## Screenshots (if applicable)

<!-- Add screenshots or log excerpts that demonstrate the change works as expected -->
