### PR TITLE
otel for logging to azmon

### DIFF
--- a/infra/modules/function-app.bicep
+++ b/infra/modules/function-app.bicep
@@ -117,6 +117,10 @@ resource functionApp 'Microsoft.Web/sites@2023-12-01' = {
           name:  'APPLICATIONINSIGHTS_CONNECTION_STRING'
           value: appInsightsConnectionString
         }
+        {
+          name:  'PYTHON_ENABLE_OPENTELEMETRY'
+          value: 'true'
+        }
         // ── Cross-tenant Service Bus (read directly by Python function code) ────
         // The function uses ClientAssertionCredential with a federated identity
         // assertion issued by the UAMI to authenticate against a Service Bus

--- a/src/function_app/function_app.py
+++ b/src/function_app/function_app.py
@@ -58,6 +58,7 @@ SB_MAX_WAIT_TIME_SECONDS        – (optional) max wait time per poll in seconds
                                   default 5
 """
 
+import base64
 import json
 import logging
 import os
@@ -66,8 +67,15 @@ from datetime import UTC, datetime
 
 import azure.functions as func
 from azure.identity import ClientAssertionCredential, ManagedIdentityCredential
+from azure.monitor.opentelemetry import configure_azure_monitor
 from azure.servicebus import ServiceBusClient, ServiceBusReceivedMessage
 from azure.storage.blob import BlobServiceClient
+
+configure_azure_monitor(
+    resource_attributes={"service.name": "cross-tenant-sb-subscriber"},
+    sampling_ratio=1.0,
+)
+logger = logging.getLogger("function_app")
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Configuration helpers
@@ -91,6 +99,46 @@ def _opt_env(name: str, default: str) -> str:
 # Credential factories
 # ──────────────────────────────────────────────────────────────────────────────
 
+def _log_token_claims(token: str, label: str) -> None:
+    """Decode a JWT payload and log key claims for troubleshooting.
+
+    Only the non-sensitive claim metadata is logged — the raw token value is
+    never written to any log destination.
+    """
+    try:
+        parts = token.split(".")
+        if len(parts) < 2:
+            logger.warning("%s token does not look like a JWT (no '.' separators).", label)
+            return
+        # Fix base64 padding
+        payload_b64 = parts[1]
+        payload_b64 += "=" * (-len(payload_b64) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(payload_b64))
+
+        def _ts(epoch) -> str:
+            """Convert a Unix epoch to ISO 8601 or return 'n/a'."""
+            if epoch is None:
+                return "n/a"
+            return datetime.fromtimestamp(int(epoch), tz=UTC).isoformat()
+
+        logger.info(
+            "%s token claims — iss: %s | aud: %s | sub: %s | oid: %s | "
+            "tid: %s | appid: %s | iat: %s | nbf: %s | exp: %s",
+            label,
+            claims.get("iss", "n/a"),
+            claims.get("aud", "n/a"),
+            claims.get("sub", "n/a"),
+            claims.get("oid", "n/a"),
+            claims.get("tid", "n/a"),
+            claims.get("appid") or claims.get("azp", "n/a"),
+            _ts(claims.get("iat")),
+            _ts(claims.get("nbf")),
+            _ts(claims.get("exp")),
+        )
+    except Exception:
+        logger.warning("Failed to decode %s token claims for diagnostics.", label, exc_info=True)
+
+
 def _build_service_bus_credential() -> ClientAssertionCredential:
     """
     Build a ``ClientAssertionCredential`` that performs the cross-tenant token
@@ -111,7 +159,9 @@ def _build_service_bus_credential() -> ClientAssertionCredential:
 
     def get_assertion() -> str:
         try:
-            return uami_credential.get_token("api://AzureADTokenExchange").token
+            token = uami_credential.get_token("api://AzureADTokenExchange").token
+            _log_token_claims(token, "UAMI federated assertion")
+            return token
         except Exception as exc:
             raise RuntimeError(
                 "Failed to obtain federated assertion token from IMDS for "
@@ -227,7 +277,7 @@ def service_bus_subscriber(timer: func.TimerRequest) -> None:
     ``ManagedIdentityCredential`` for same-tenant Blob Storage access.
     """
     if timer.past_due:
-        logging.warning("Timer is past due; processing may have been delayed.")
+        logger.warning("Timer is past due; processing may have been delayed.")
 
     # ── Required configuration ────────────────────────────────────────────────
     sb_namespace = _require_env("CROSS_TENANT_SERVICE_BUS_NAMESPACE")
@@ -269,20 +319,20 @@ def service_bus_subscriber(timer: func.TimerRequest) -> None:
                         blob_service_client, container_name, message
                     )
                     receiver.complete_message(message)
-                    logging.info(
+                    logger.info(
                         "Message %s written to blob '%s'.",
                         message.message_id,
                         blob_name,
                     )
                     processed += 1
                 except Exception:  # noqa: BLE001
-                    logging.exception(
+                    logger.exception(
                         "Failed to process message %s; abandoning.",
                         message.message_id,
                     )
                     receiver.abandon_message(message)
                     failed += 1
 
-    logging.info(
+    logger.info(
         "Poll complete: %d processed, %d failed/abandoned.", processed, failed
     )

--- a/src/function_app/requirements.txt
+++ b/src/function_app/requirements.txt
@@ -1,4 +1,5 @@
 azure-functions>=1.21.0,<2.0.0
 azure-identity>=1.17.0,<2.0.0
+azure-monitor-opentelemetry>=1.6.4,<2.0.0
 azure-servicebus>=7.12.0,<8.0.0
 azure-storage-blob>=12.22.0,<13.0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+"""Shared test fixtures for the Cross-Tenant Service Bus Subscriber tests."""
+
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mock_configure_azure_monitor():
+    """Prevent the OpenTelemetry SDK from initialising during unit tests.
+
+    ``configure_azure_monitor()`` is called at module level in
+    ``function_app.py``.  Every ``importlib.reload(fa)`` re-executes it, which
+    would fail without ``APPLICATIONINSIGHTS_CONNECTION_STRING`` and produce
+    unwanted side-effects.  This autouse fixture patches it for every test.
+    """
+    with patch("azure.monitor.opentelemetry.configure_azure_monitor"):
+        yield

--- a/tests/test_function_app.py
+++ b/tests/test_function_app.py
@@ -448,7 +448,7 @@ class TestServiceBusSubscriber:
             patch.object(fa, "BlobServiceClient"),
             patch.object(fa, "_build_service_bus_credential"),
             patch.object(fa, "_build_storage_credential"),
-            caplog.at_level(logging.WARNING),
+            caplog.at_level(logging.WARNING, logger="function_app"),
         ):
             fa.service_bus_subscriber(_make_timer(past_due=True))
 
@@ -499,3 +499,77 @@ class TestServiceBusSubscriber:
         receiver.receive_messages.assert_called_once_with(
             max_message_count=42, max_wait_time=3.0
         )
+
+
+# ── Tests: _log_token_claims ─────────────────────────────────────────────────
+
+def _make_fake_jwt(claims: dict) -> str:
+    """Build a fake JWT (header.payload.signature) from a claims dict."""
+    import base64 as _b64
+    header = _b64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode()
+    payload = _b64.urlsafe_b64encode(
+        json.dumps(claims).encode()
+    ).rstrip(b"=").decode()
+    return f"{header}.{payload}.fakesig"
+
+
+class TestLogTokenClaims:
+    def test_logs_key_claims_at_info(self, caplog):
+        """A valid JWT must produce an INFO log containing all key claims."""
+        import importlib
+        import logging
+        import function_app as fa
+        importlib.reload(fa)
+
+        claims = {
+            "iss": "https://login.microsoftonline.com/tenant-a/v2.0",
+            "aud": "api://AzureADTokenExchange",
+            "sub": "uami-principal-id",
+            "oid": "object-id-123",
+            "tid": "tenant-a-id",
+            "appid": "app-client-id",
+            "iat": 1700000000,
+            "nbf": 1700000000,
+            "exp": 1700003600,
+        }
+        token = _make_fake_jwt(claims)
+
+        with caplog.at_level(logging.INFO, logger="function_app"):
+            fa._log_token_claims(token, "test")
+
+        assert len(caplog.records) == 1
+        msg = caplog.records[0].message
+        assert "iss: https://login.microsoftonline.com/tenant-a/v2.0" in msg
+        assert "aud: api://AzureADTokenExchange" in msg
+        assert "sub: uami-principal-id" in msg
+        assert "tid: tenant-a-id" in msg
+        assert "appid: app-client-id" in msg
+
+    def test_malformed_token_logs_warning_no_raise(self, caplog):
+        """A non-JWT string must log a warning and must NOT raise."""
+        import importlib
+        import logging
+        import function_app as fa
+        importlib.reload(fa)
+
+        with caplog.at_level(logging.WARNING, logger="function_app"):
+            fa._log_token_claims("not-a-jwt", "bad")
+
+        assert any("does not look like a JWT" in r.message for r in caplog.records)
+
+    def test_missing_claims_logs_gracefully(self, caplog):
+        """A JWT with no standard claims must still log without error."""
+        import importlib
+        import logging
+        import function_app as fa
+        importlib.reload(fa)
+
+        token = _make_fake_jwt({"custom": "value"})
+
+        with caplog.at_level(logging.INFO, logger="function_app"):
+            fa._log_token_claims(token, "sparse")
+
+        assert len(caplog.records) == 1
+        msg = caplog.records[0].message
+        assert "iss: n/a" in msg
+        assert "aud: n/a" in msg


### PR DESCRIPTION
This pull request adds OpenTelemetry monitoring to the Function App, improves logging and diagnostics, and introduces a helper for decoding and logging JWT token claims. It also updates tests to cover the new logging functionality and ensures OpenTelemetry initialization is suppressed during unit tests.

**Observability and Monitoring Enhancements:**

* Added `azure-monitor-opentelemetry` dependency and configured Azure Monitor OpenTelemetry at module level in `function_app.py` for improved distributed tracing and metrics. [[1]](diffhunk://#diff-d288d999f8822aaf86057f45495277186ee9f7a7a8c75db012b30c6212cd6b6dR3) [[2]](diffhunk://#diff-f988fe2705d25b9e1b92f91623041e5c60b1af4aee02b857bdaa9197e1d62c1eR70-R79)
* Set the `PYTHON_ENABLE_OPENTELEMETRY` environment variable in the Function App deployment to enable OpenTelemetry instrumentation.

**Logging Improvements and Diagnostics:**

* Introduced a module-level `logger` and replaced all `logging` calls with `logger` for consistent logging configuration. [[1]](diffhunk://#diff-f988fe2705d25b9e1b92f91623041e5c60b1af4aee02b857bdaa9197e1d62c1eR70-R79) [[2]](diffhunk://#diff-f988fe2705d25b9e1b92f91623041e5c60b1af4aee02b857bdaa9197e1d62c1eL230-R280) [[3]](diffhunk://#diff-f988fe2705d25b9e1b92f91623041e5c60b1af4aee02b857bdaa9197e1d62c1eL272-R336)
* Added `_log_token_claims()` helper to decode JWT payloads and log key claims for troubleshooting, integrated into the Service Bus credential flow. [[1]](diffhunk://#diff-f988fe2705d25b9e1b92f91623041e5c60b1af4aee02b857bdaa9197e1d62c1eR102-R141) [[2]](diffhunk://#diff-f988fe2705d25b9e1b92f91623041e5c60b1af4aee02b857bdaa9197e1d62c1eL114-R164)

**Testing Enhancements:**

* Added tests for `_log_token_claims()` covering valid, malformed, and sparse JWTs, ensuring robust diagnostics without leaking sensitive information.
* Introduced a pytest fixture in `conftest.py` to patch `configure_azure_monitor()` and prevent OpenTelemetry initialization during unit tests.
* Updated logging assertions in tests to use the new logger name.